### PR TITLE
docs(README): Fix Formulae Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ brew install socktainer
 
 | Source                                                            | Formula                                  | Description                                                           |
 | ----------------------------------------------------------------- | ---------------------------------------- | --------------------------------------------------------------------- |
-| [socktainer/socktainer](https://github.com/socktainer/socktainer) | [socktainer.rb](./Formula/socktainer.rb) | **[Temporary]** Docker-compatible REST API on top of Apple container. |
+| [socktainer/socktainer](https://github.com/socktainer/socktainer) | [socktainer.rb](./Formula/socktainer.rb) | Docker-compatible REST API on top of Apple container. |


### PR DESCRIPTION
Removing the `temporary` keyword.

Signed-off-by: Vadim Khitrin <me@vkhitrin.com>