### PR TITLE
chore(distribution): Add `socktainer-next`

### DIFF
--- a/Formula/socktainer-next.rb
+++ b/Formula/socktainer-next.rb
@@ -1,0 +1,45 @@
+class SocktainerNext < Formula
+  version "0.2.0-next.202509261430-96f5b14"
+  desc "Docker-compatible REST API on top of Apple container"
+  homepage "https://github.com/socktainer/socktainer"
+  url "https://github.com/socktainer/prereleases/releases/download/v#{version}/socktainer.zip"
+  sha256 "2c8d578a34356a94cf512200233e2252739ebb0b5e06132e3583a82ae53e7239"
+  livecheck do
+    url(:url)
+    strategy(:github_latest)
+  end
+
+  license "Apache-2.0"
+
+  depends_on :macos
+  depends_on arch: :arm64
+  depends_on macos: :tahoe
+
+  conflicts_with "socktainer", because: "both install `socktainer` binaries"
+
+
+  def install
+      bin.install("socktainer")
+  end
+
+  service do
+    run [opt_bin / "socktainer"]
+    keep_alive true
+    environment_variables PATH: std_service_path_env
+    log_path var / "log/socktainer.log"
+    error_log_path var / "log/socktainer-error.log"
+  end
+
+  def caveats
+    <<~EOS
+      This is a pre-release version!
+
+      Requires native Apple macOS container (https://github.com/apple/container)
+      Currently, Apple container is not a dependency of this Formula.
+    EOS
+  end
+
+  test do
+    assert_match "socktainer", shell_output("#{bin}/socktainer --help")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ brew install socktainer
 
 ## Formulae
 
-| Source                                                            | Formula                                  | Description                                                           |
-| ----------------------------------------------------------------- | ---------------------------------------- | --------------------------------------------------------------------- |
-| [socktainer/socktainer](https://github.com/socktainer/socktainer) | [socktainer.rb](./Formula/socktainer.rb) | Docker-compatible REST API on top of Apple container. |
+| Source                                                              | Formula                                            | Description                                                             |
+| ------------------------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------- |
+| [socktainer/socktainer](https://github.com/socktainer/socktainer)   | [socktainer.rb](./Formula/socktainer.rb)           | Docker-compatible REST API on top of Apple container.                   |
+| [socktainer/prereleases](https://github.com/socktainer/prereleases) | [socktainer-next.rb](./Formula/socktainer-next.rb) | **[PRE-RELEASE]** Docker-compatible REST API on top of Apple container. |


### PR DESCRIPTION
Adding formula to install pre-release versions of socktainer.
Resolves #5.
