### PR TITLE
fix: socktainer v0.11.0

### DIFF
--- a/Formula/socktainer.rb
+++ b/Formula/socktainer.rb
@@ -1,23 +1,22 @@
 class Socktainer < Formula
-  version "0.9.1"
   desc "Docker-compatible REST API on top of Apple container"
   homepage "https://github.com/socktainer/socktainer"
-  url "https://github.com/socktainer/socktainer/releases/download/v#{version}/socktainer.zip"
-  sha256 "27298733dc662a28c8597ee92251d0023adbfd09877a6d685349ae2a6a5c9874"
+  url "https://github.com/socktainer/socktainer/releases/download/v0.11.0/socktainer.zip"
+  sha256 "aaa1090f9881615c8d6d95c9cba77c61c00e9bb26964a89ab0a625e28a80685c"
+  license "Apache-2.0"
+  head "https://github.com/socktainer/socktainer.git", branch: "main"
+
   livecheck do
     url(:url)
     strategy(:github_latest)
   end
 
-  conflicts_with "socktainer-next", because: "both install `socktainer` binaries"
-
-  license "Apache-2.0"
-  head "https://github.com/socktainer/socktainer.git", branch: "main"
-
-  depends_on :macos
   depends_on xcode: ["26.0", :build] if build.head?
   depends_on arch: :arm64
+  depends_on :macos
   depends_on macos: :tahoe
+
+  conflicts_with "socktainer-next", because: "both install `socktainer` binaries"
 
   def install
     if build.head?


### PR DESCRIPTION
update formula to latest socktainer release.  also includes fixes from
`brew audit --strict --fix socktainer`.
