### PR TITLE
fix depends_on :macos deprecation warning

### DIFF
--- a/Formula/socktainer-next.rb
+++ b/Formula/socktainer-next.rb
@@ -11,9 +11,11 @@ class SocktainerNext < Formula
 
   license "Apache-2.0"
 
-  depends_on :macos
   depends_on arch: :arm64
-  depends_on macos: :tahoe
+
+  on_macos do
+    depends_on macos: :tahoe
+  end
 
   conflicts_with "socktainer", because: "both install `socktainer` binaries"
 

--- a/Formula/socktainer.rb
+++ b/Formula/socktainer.rb
@@ -13,8 +13,10 @@ class Socktainer < Formula
 
   depends_on xcode: ["26.0", :build] if build.head?
   depends_on arch: :arm64
-  depends_on :macos
-  depends_on macos: :tahoe
+
+  on_macos do
+    depends_on macos: :tahoe
+  end
 
   conflicts_with "socktainer-next", because: "both install `socktainer` binaries"
 


### PR DESCRIPTION
Original deprecation warning:

```
Warning: Calling `depends_on :macos` with `depends_on macos:` is deprecated! Use
  `depends_on :macos` with `depends_on macos:` inside an `on_macos`
block instead.
  Please report this issue to the socktainer/homebrew-tap tap (not
Homebrew/* repositories),
  or even better, submit a PR to fix it:

/opt/homebrew/Library/Taps/socktainer/homebrew-tap/Formula/socktainer-next.rb:16
```